### PR TITLE
Update 10-api-driven-example: extraneous to_s method. in /app/models/color.rb

### DIFF
--- a/10-api-driven-example/Colr/app/models/color.rb
+++ b/10-api-driven-example/Colr/app/models/color.rb
@@ -7,7 +7,7 @@ class Color
   def initialize(hash = {})
     hash.each { |key, value|
       if PROPERTIES.member? key.to_sym
-        self.send((key.to_s + "=").to_s, value)
+        self.send((key.to_s + "="), value)
       end
     }
   end


### PR DESCRIPTION
extraneous to_s method.

Made sure this is the case with RubyMotion's ruby:

```
$ rake
main> {key: "value"}.each {|key, value| puts (key.to_s+"=").class; puts value.class}
String
String
=> {:key=>"value"}
```
