### PR TITLE
define_method is availabe as of RubyMotion 1.24

### DIFF
--- a/_posts/chapters/1900-01-01-0-in-motion.md
+++ b/_posts/chapters/1900-01-01-0-in-motion.md
@@ -19,7 +19,7 @@ But despite its strengths, many programmers balk at the prospect of learning a n
 
 [RubyMotion][motion] is such a solution. It allows you to write iOS apps in [Ruby][ruby] with no penalty to user experience. And it preserves the iOS SDK exactly as intended by Apple, so all exisiting code examples and tutorials are perfectly translateable.
 
-How does that work? Well, technically it's a *variant* of Ruby; you can't use some of Ruby's extremely dynamic methods like `eval` or `define_method`, and it adds some new features like `functions.with(some, named: parameters)`. This allows your Ruby code to be compiled to machine code identical to Objective-C; in other words, the device can't tell the difference between RubyMotion and normal iOS apps.
+How does that work? Well, technically it's a *variant* of Ruby; you can't use some of Ruby's extremely dynamic methods like `eval`, and it adds some new features like `functions.with(some, named: parameters)`. This allows your Ruby code to be compiled to machine code identical to Objective-C; in other words, the device can't tell the difference between RubyMotion and normal iOS apps.
 
 If you just don't like Ruby, RubyMotion won't change your mind. But if you aren't totally anti-Ruby, or you're just a developer who wants to write apps in a language farther away from the metal, I highly recommend you give RubyMotion a chance.
 


### PR DESCRIPTION
define_method is availabe as of RubyMotion 1.24
(because of technical limitations of the static compiler, it is not possible yet to use #define_method to overwrite an existing Objective-C-level method)
