### PR TITLE
bug fix on conditional statement

### DIFF
--- a/7-models/index.html
+++ b/7-models/index.html
@@ -142,7 +142,7 @@
 
   <span class="k">def</span> <span class="nf">initialize</span><span class="p">(</span><span class="n">attributes</span> <span class="o">=</span> <span class="p">{})</span>
     <span class="n">attributes</span><span class="o">.</span><span class="n">each</span> <span class="p">{</span> <span class="o">|</span><span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="o">|</span>
-      <span class="nb">self</span><span class="o">.</span><span class="n">send</span><span class="p">(</span><span class="s2">&quot;</span><span class="si">#{</span><span class="n">key</span><span class="si">}</span><span class="s2">=&quot;</span><span class="p">,</span> <span class="n">value</span><span class="p">)</span> <span class="k">if</span> <span class="no">PROPERTIES</span><span class="o">.</span><span class="n">member?</span> <span class="n">key</span>
+      <span class="nb">self</span><span class="o">.</span><span class="n">send</span><span class="p">(</span><span class="s2">&quot;</span><span class="si">#{</span><span class="n">key</span><span class="si">}</span><span class="s2">=&quot;</span><span class="p">,</span> <span class="n">value</span><span class="p">)</span> <span class="k">if</span> <span class="no">PROPERTIES</span><span class="o">.</span><span class="n">member?</span> <span class="n">key<span class="o">.</span><span class="n">to_sym</span></span>
     <span class="p">}</span>
   <span class="k">end</span>
 <span class="k">end</span>


### PR DESCRIPTION
`f PROPERTIES.member? key`

becomes

`if PROPERTIES.member? key.to_sym`

to fix a bug where if the hash provided to Object.new contains String keys, the instance variables are not actually set on the Object. (i.e. the conditional statement requires Symbols, and doesn't recognise Strings). This is important when e.g. Object.new(json_from_server)
