### PR TITLE
set background color to labels for iOS7

### DIFF
--- a/7-models/KeyValueFun/app/app_delegate.rb
+++ b/7-models/KeyValueFun/app/app_delegate.rb
@@ -8,12 +8,15 @@ class AppDelegate
     @window.makeKeyAndVisible
 
     @name_label = UILabel.alloc.initWithFrame([[0, 0], [100, 30]])
+    @name_label.backgroundColor = UIColor.whiteColor
     @window.addSubview(@name_label)
 
     @email_label = UILabel.alloc.initWithFrame([[0, @name_label.frame.size.height + 10], @name_label.frame.size])
+    @email_label.backgroundColor = UIColor.whiteColor
     @window.addSubview(@email_label)
 
     @id_label = UILabel.alloc.initWithFrame([[0, @email_label.frame.origin.y + @email_label.frame.size.height + 10], @name_label.frame.size])
+    @id_label.backgroundColor = UIColor.whiteColor
     @window.addSubview(@id_label)
 
     self.user = User.new


### PR DESCRIPTION
Hi, thank you for this nice tutorial about RubyMotion.
I am studying RubyMotion with it now, but in chapter 7 I did not get the same UI result as showed in the article. To be precise, each UILabel were showed but its background color was black, so I did not see whether I got the right result.

This commit simply fixes the background color of each UILabel to white.
