### PR TITLE
Fix links to Bubble Wrap docs

### DIFF
--- a/_posts/chapters/1900-01-07-7-models.md
+++ b/_posts/chapters/1900-01-07-7-models.md
@@ -191,7 +191,7 @@ gem 'bubble-wrap'
 ...
 ```
 
-...and then run `bundle install` from your terminal. 
+...and then run `bundle install` from your terminal.
 
 Now to the real code. In `user.rb`, you can either use the robust, API-friendly `User` class outlined above or use the more concise (but still workable) version:
 
@@ -295,6 +295,6 @@ We've been playing around with the "sexy" parts of iOS for a bit, but at the end
 
 [Use the force to see how RubyMotion handles Testing!](/8-testing)
 
-[bw]: http://bubblewrap.io/
+[bw]: http://rubymotion.github.io/BubbleWrap/
 
 [gems]: http://rubygems.org/pages/download

--- a/_posts/chapters/1900-01-09-9-http.md
+++ b/_posts/chapters/1900-01-09-9-http.md
@@ -48,6 +48,6 @@ Wait a second, what are we actually going to make?
 
 [Get ready for an example on how to build an API-driven App!](/10-api-driven-example)
 
-[bw]: http://bubblewrap.io/
+[bw]: http://rubymotion.github.io/BubbleWrap/
 
 [docs]: https://github.com/rubymotion/BubbleWrap/blob/master/motion/http.rb


### PR DESCRIPTION
http://bubblewrap.io/ is not resolving so these changes fix links to those docs. Keep up the good work!